### PR TITLE
Fix invalid Keras requirement specifier

### DIFF
--- a/BRAIN TUMOR DETECTION [END 2 END]/requirements.txt
+++ b/BRAIN TUMOR DETECTION [END 2 END]/requirements.txt
@@ -1,4 +1,4 @@
 python==3.5
 tensorflow==1.5
-keras=1.1.0
+keras==1.1.0
 flask


### PR DESCRIPTION
## Description

Fixes the invalid Keras version specifier in the Brain Tumor Detection project's `requirements.txt`.

### Changes

Changed:

```text
keras=1.1.0
```

to:

```text
keras==1.1.0
```

This fixes the pip parsing error:

```text
ERROR: Invalid requirement: 'keras=1.1.0'
```

### Related Issue

Closes #43
